### PR TITLE
docs: add database ER diagram (Mermaid) incl. RSS feed ingestion

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -4,6 +4,7 @@
 
 ```mermaid
 erDiagram
+  %% Users and social graph
   USER ||--o{ POST : authors
   USER ||--o{ LIKE : likes
   USER ||--o{ BOOKMARK : bookmarks
@@ -13,14 +14,29 @@ erDiagram
   USER ||--o{ POST_SHARE : shares
   USER ||--o{ USER_TECHNOLOGY : uses
 
+  %% Posts relationships
   POST ||--o{ LIKE : liked_by
   POST ||--o{ BOOKMARK : bookmarked_by
   POST ||--o{ COMMENT : comments
   POST ||--o{ POST_HASHTAG : tagged_with
   POST ||--o{ POST_SHARE : shared_as
 
+  %% Hashtags
   HASHTAG ||--o{ POST_HASHTAG : used_in
   TECHNOLOGY ||--o{ USER_TECHNOLOGY : used_by
+
+  %% RSS ingestion and feed curation
+  RSS_SOURCE ||--o{ RSS_ENTRY : provides
+  RSS_ENTRY ||--o{ RSS_ENCLOSURE : has_media
+  RSS_ENTRY ||--o{ RSS_ENTRY_HASHTAG : tagged_with
+  HASHTAG ||--o{ RSS_ENTRY_HASHTAG : used_in
+  RSS_SOURCE ||--o{ RSS_FETCH_LOG : fetches
+  RSS_SOURCE ||--o{ SOURCE_TECHNOLOGY : categorized_as
+  TECHNOLOGY ||--o{ SOURCE_TECHNOLOGY : category_map
+
+  %% Feed items referencing either RSS entries or future posts
+  FEED_ITEM }o--|| RSS_ENTRY : references
+  FEED_ITEM }o--|| POST : references
 
   USER {
     uuid id PK
@@ -35,7 +51,7 @@ erDiagram
   POST {
     uuid id PK
     uuid author_id FK
-    string type
+    string type %% text|video
     string title
     string body
     string video_url
@@ -97,7 +113,7 @@ erDiagram
   NOTIFICATION {
     uuid id PK
     uuid user_id FK
-    string type
+    string type %% like|comment|follow|share
     uuid actor_id FK
     uuid post_id FK
     uuid comment_id FK
@@ -120,10 +136,95 @@ erDiagram
     uuid technology_id FK
     timestamp created_at
   }
+
+  %% RSS ingestion
+  RSS_SOURCE {
+    uuid id PK
+    string feed_url UK
+    string site_url
+    string title
+    string description
+    string language
+    string category
+    boolean is_active
+    integer fetch_interval_minutes
+    string etag
+    string last_modified
+    timestamp last_fetched_at
+    timestamp created_at
+    timestamp updated_at
+  }
+
+  RSS_ENTRY {
+    uuid id PK
+    uuid source_id FK
+    string guid
+    string link
+    string title
+    string description
+    string content_html
+    string content_text
+    string author_name
+    string language
+    string image_url
+    timestamp published_at
+    timestamp updated_at
+    string content_hash %% for deduplication
+  }
+
+  RSS_ENCLOSURE {
+    uuid id PK
+    uuid entry_id FK
+    string url
+    string mime_type
+    integer length
+    string thumbnail_url
+  }
+
+  RSS_ENTRY_HASHTAG {
+    uuid id PK
+    uuid entry_id FK
+    uuid hashtag_id FK
+  }
+
+  RSS_FETCH_LOG {
+    uuid id PK
+    uuid source_id FK
+    timestamp started_at
+    timestamp finished_at
+    integer http_status
+    integer fetched_count
+    integer inserted_count
+    integer updated_count
+    integer duration_ms
+    string error_message
+  }
+
+  SOURCE_TECHNOLOGY {
+    uuid id PK
+    uuid source_id FK
+    uuid technology_id FK
+    timestamp created_at
+  }
+
+  %% Feed curation
+  FEED_ITEM {
+    uuid id PK
+    string type %% rss|post
+    uuid rss_entry_id FK
+    uuid post_id FK
+    boolean is_published
+    float rank_score
+    timestamp published_at
+    timestamp created_at
+    timestamp updated_at
+  }
 ```
 
 補足:
 - 認証は NextAuth.js を想定。必要に応じて `Account`, `Session`, `VerificationToken` を追加可能（Auth.js Prisma Adapter準拠）。
-- `POST.type` は `text | video` を想定。
-- 複合ユニーク制約（例: `LIKE(user_id, post_id)`、`BOOKMARK(user_id, post_id)`、`FOLLOW(follower_id, following_id)`、`POST_HASHTAG(post_id, hashtag_id)`、`USER_TECHNOLOGY(user_id, technology_id)`）はDBで付与してください（Mermaidの記法上は注釈のみ）。
+- `POST.type` は `text | video` を想定（将来リリース）。現段階のフィードは `FEED_ITEM` で `RSS_ENTRY` を参照します。
+- 複合ユニーク制約（例: `LIKE(user_id, post_id)`、`BOOKMARK(user_id, post_id)`、`FOLLOW(follower_id, following_id)`、`POST_HASHTAG(post_id, hashtag_id)`、`USER_TECHNOLOGY(user_id, technology_id)`、`RSS_ENTRY(source_id, guid)`、`RSS_ENTRY_HASHTAG(entry_id, hashtag_id)`、`SOURCE_TECHNOLOGY(source_id, technology_id)`）はDBで付与してください（Mermaidの記法上は注釈のみ）。
+- 重複排除用に `RSS_ENTRY.content_hash` を保持。`guid` がない/不安定なフィードにも対応。
+- 画像/動画などのメディアは `RSS_ENCLOSURE` に格納し、必要に応じて `thumbnail_url` を `FEED_ITEM` 描画に活用。
 - 統計値は集計で取得する想定。高頻度で必要なら `post_metrics` や `user_metrics` のマテビュー/集計テーブルを別途追加。

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -4,7 +4,6 @@
 
 ```mermaid
 erDiagram
-  %% Users and social graph
   USER ||--o{ POST : authors
   USER ||--o{ LIKE : likes
   USER ||--o{ BOOKMARK : bookmarks
@@ -14,18 +13,15 @@ erDiagram
   USER ||--o{ POST_SHARE : shares
   USER ||--o{ USER_TECHNOLOGY : uses
 
-  %% Posts relationships
   POST ||--o{ LIKE : liked_by
   POST ||--o{ BOOKMARK : bookmarked_by
   POST ||--o{ COMMENT : comments
   POST ||--o{ POST_HASHTAG : tagged_with
   POST ||--o{ POST_SHARE : shared_as
 
-  %% Hashtags
   HASHTAG ||--o{ POST_HASHTAG : used_in
   TECHNOLOGY ||--o{ USER_TECHNOLOGY : used_by
 
-  %% RSS ingestion and feed curation
   RSS_SOURCE ||--o{ RSS_ENTRY : provides
   RSS_ENTRY ||--o{ RSS_ENCLOSURE : has_media
   RSS_ENTRY ||--o{ RSS_ENTRY_HASHTAG : tagged_with
@@ -34,112 +30,110 @@ erDiagram
   RSS_SOURCE ||--o{ SOURCE_TECHNOLOGY : categorized_as
   TECHNOLOGY ||--o{ SOURCE_TECHNOLOGY : category_map
 
-  %% Feed items referencing either RSS entries or future posts
   FEED_ITEM }o--|| RSS_ENTRY : references
   FEED_ITEM }o--|| POST : references
 
   USER {
-    uuid id PK
+    string id PK
     string username UK
     string display_name
     string avatar_url
     string bio
-    timestamp created_at
-    timestamp updated_at
+    datetime created_at
+    datetime updated_at
   }
 
   POST {
-    uuid id PK
-    uuid author_id FK
-    string type %% text|video
+    string id PK
+    string author_id FK
+    string type
     string title
     string body
     string video_url
     string thumbnail_url
-    timestamp created_at
-    timestamp updated_at
+    datetime created_at
+    datetime updated_at
   }
 
   LIKE {
-    uuid id PK
-    uuid user_id FK
-    uuid post_id FK
-    timestamp created_at
+    string id PK
+    string user_id FK
+    string post_id FK
+    datetime created_at
   }
 
   BOOKMARK {
-    uuid id PK
-    uuid user_id FK
-    uuid post_id FK
-    timestamp created_at
+    string id PK
+    string user_id FK
+    string post_id FK
+    datetime created_at
   }
 
   COMMENT {
-    uuid id PK
-    uuid post_id FK
-    uuid user_id FK
+    string id PK
+    string post_id FK
+    string user_id FK
     string body
-    uuid parent_comment_id FK
-    timestamp created_at
-    timestamp updated_at
+    string parent_comment_id FK
+    datetime created_at
+    datetime updated_at
   }
 
   FOLLOW {
-    uuid id PK
-    uuid follower_id FK
-    uuid following_id FK
-    timestamp created_at
+    string id PK
+    string follower_id FK
+    string following_id FK
+    datetime created_at
   }
 
   HASHTAG {
-    uuid id PK
+    string id PK
     string name UK
-    timestamp created_at
+    datetime created_at
   }
 
   POST_HASHTAG {
-    uuid id PK
-    uuid post_id FK
-    uuid hashtag_id FK
+    string id PK
+    string post_id FK
+    string hashtag_id FK
   }
 
   POST_SHARE {
-    uuid id PK
-    uuid post_id FK
-    uuid user_id FK
-    timestamp created_at
+    string id PK
+    string post_id FK
+    string user_id FK
+    datetime created_at
   }
 
   NOTIFICATION {
-    uuid id PK
-    uuid user_id FK
-    string type %% like|comment|follow|share
-    uuid actor_id FK
-    uuid post_id FK
-    uuid comment_id FK
+    string id PK
+    string user_id FK
+    string type
+    string actor_id FK
+    string post_id FK
+    string comment_id FK
     boolean is_read
-    timestamp created_at
+    datetime created_at
   }
 
   TECHNOLOGY {
-    uuid id PK
+    string id PK
     string name
     string category
     string color
-    timestamp created_at
-    timestamp updated_at
+    datetime created_at
+    datetime updated_at
   }
 
   USER_TECHNOLOGY {
-    uuid id PK
-    uuid user_id FK
-    uuid technology_id FK
-    timestamp created_at
+    string id PK
+    string user_id FK
+    string technology_id FK
+    datetime created_at
   }
 
-  %% RSS ingestion
   RSS_SOURCE {
-    uuid id PK
+    string id PK
     string feed_url UK
     string site_url
     string title
@@ -147,17 +141,17 @@ erDiagram
     string language
     string category
     boolean is_active
-    integer fetch_interval_minutes
+    int fetch_interval_minutes
     string etag
     string last_modified
-    timestamp last_fetched_at
-    timestamp created_at
-    timestamp updated_at
+    datetime last_fetched_at
+    datetime created_at
+    datetime updated_at
   }
 
   RSS_ENTRY {
-    uuid id PK
-    uuid source_id FK
+    string id PK
+    string source_id FK
     string guid
     string link
     string title
@@ -167,64 +161,63 @@ erDiagram
     string author_name
     string language
     string image_url
-    timestamp published_at
-    timestamp updated_at
-    string content_hash %% for deduplication
+    datetime published_at
+    datetime updated_at
+    string content_hash
   }
 
   RSS_ENCLOSURE {
-    uuid id PK
-    uuid entry_id FK
+    string id PK
+    string entry_id FK
     string url
     string mime_type
-    integer length
+    int length
     string thumbnail_url
   }
 
   RSS_ENTRY_HASHTAG {
-    uuid id PK
-    uuid entry_id FK
-    uuid hashtag_id FK
+    string id PK
+    string entry_id FK
+    string hashtag_id FK
   }
 
   RSS_FETCH_LOG {
-    uuid id PK
-    uuid source_id FK
-    timestamp started_at
-    timestamp finished_at
-    integer http_status
-    integer fetched_count
-    integer inserted_count
-    integer updated_count
-    integer duration_ms
+    string id PK
+    string source_id FK
+    datetime started_at
+    datetime finished_at
+    int http_status
+    int fetched_count
+    int inserted_count
+    int updated_count
+    int duration_ms
     string error_message
   }
 
   SOURCE_TECHNOLOGY {
-    uuid id PK
-    uuid source_id FK
-    uuid technology_id FK
-    timestamp created_at
+    string id PK
+    string source_id FK
+    string technology_id FK
+    datetime created_at
   }
 
-  %% Feed curation
   FEED_ITEM {
-    uuid id PK
-    string type %% rss|post
-    uuid rss_entry_id FK
-    uuid post_id FK
+    string id PK
+    string type
+    string rss_entry_id FK
+    string post_id FK
     boolean is_published
     float rank_score
-    timestamp published_at
-    timestamp created_at
-    timestamp updated_at
+    datetime published_at
+    datetime created_at
+    datetime updated_at
   }
 ```
 
 補足:
 - 認証は NextAuth.js を想定。必要に応じて `Account`, `Session`, `VerificationToken` を追加可能（Auth.js Prisma Adapter準拠）。
 - `POST.type` は `text | video` を想定（将来リリース）。現段階のフィードは `FEED_ITEM` で `RSS_ENTRY` を参照します。
-- 複合ユニーク制約（例: `LIKE(user_id, post_id)`、`BOOKMARK(user_id, post_id)`、`FOLLOW(follower_id, following_id)`、`POST_HASHTAG(post_id, hashtag_id)`、`USER_TECHNOLOGY(user_id, technology_id)`、`RSS_ENTRY(source_id, guid)`、`RSS_ENTRY_HASHTAG(entry_id, hashtag_id)`、`SOURCE_TECHNOLOGY(source_id, technology_id)`）はDBで付与してください（Mermaidの記法上は注釈のみ）。
-- 重複排除用に `RSS_ENTRY.content_hash` を保持。`guid` がない/不安定なフィードにも対応。
-- 画像/動画などのメディアは `RSS_ENCLOSURE` に格納し、必要に応じて `thumbnail_url` を `FEED_ITEM` 描画に活用。
+- 複合ユニーク制約（例: `LIKE(user_id, post_id)`、`BOOKMARK(user_id, post_id)`、`FOLLOW(follower_id, following_id)`、`POST_HASHTAG(post_id, hashtag_id)`、`USER_TECHNOLOGY(user_id, technology_id)`、`RSS_ENTRY(source_id, guid)`、`RSS_ENTRY_HASHTAG(entry_id, hashtag_id)`、`SOURCE_TECHNOLOGY(source_id, technology_id)`）はDBで付与してください。
+- 重複排除用に `RSS_ENTRY.content_hash` を保持。
+- メディアは `RSS_ENCLOSURE` に格納し、必要に応じて `thumbnail_url` を `FEED_ITEM` 描画に活用。
 - 統計値は集計で取得する想定。高頻度で必要なら `post_metrics` や `user_metrics` のマテビュー/集計テーブルを別途追加。

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,115 @@
+# Database Schema (Mermaid)
+
+アプリの要件と既存の型定義から、初期リリースに必要なテーブルを定義します。データベースは PostgreSQL を想定し、Prisma などのORM導入を前提に正規化します。
+
+```mermaid
+erDiagram
+  USER ||--o{ POST : "authors"
+  USER ||--o{ LIKE : "likes"
+  USER ||--o{ BOOKMARK : "bookmarks"
+  USER ||--o{ FOLLOW : "follows"
+  USER ||--o{ COMMENT : "comments"
+  USER ||--o{ NOTIFICATION : "receives"
+
+  POST ||--o{ LIKE : "liked by"
+  POST ||--o{ BOOKMARK : "bookmarked by"
+  POST ||--o{ COMMENT : "comments"
+  POST ||--o{ POST_HASHTAG : "tags"
+  POST ||--o{ POST_SHARE : "shares"
+
+  HASHTAG ||--o{ POST_HASHTAG : "used in"
+
+  FOLLOWER(USER) ||--o{ FOLLOW : "follows"
+  FOLLOWING(USER) ||--o{ FOLLOW : "followed"
+
+  USER {
+    uuid id PK
+    text username UK
+    text display_name
+    text avatar_url
+    text bio
+    timestamp created_at
+    timestamp updated_at
+  }
+
+  POST {
+    uuid id PK
+    uuid author_id FK
+    enum type "text|video"
+    text title
+    text body
+    text video_url
+    text thumbnail_url
+    timestamp created_at
+    timestamp updated_at
+  }
+
+  LIKE {
+    uuid id PK
+    uuid user_id FK
+    uuid post_id FK
+    timestamp created_at
+    UNIQUE(user_id, post_id)
+  }
+
+  BOOKMARK {
+    uuid id PK
+    uuid user_id FK
+    uuid post_id FK
+    timestamp created_at
+    UNIQUE(user_id, post_id)
+  }
+
+  COMMENT {
+    uuid id PK
+    uuid post_id FK
+    uuid user_id FK
+    text body
+    uuid parent_comment_id FK "nullable for threads"
+    timestamp created_at
+    timestamp updated_at
+  }
+
+  FOLLOW {
+    uuid id PK
+    uuid follower_id FK
+    uuid following_id FK
+    timestamp created_at
+    UNIQUE(follower_id, following_id)
+  }
+
+  HASHTAG {
+    uuid id PK
+    text name UK
+    timestamp created_at
+  }
+
+  POST_HASHTAG {
+    uuid id PK
+    uuid post_id FK
+    uuid hashtag_id FK
+    UNIQUE(post_id, hashtag_id)
+  }
+
+  POST_SHARE {
+    uuid id PK
+    uuid post_id FK
+    uuid user_id FK
+    timestamp created_at
+  }
+
+  NOTIFICATION {
+    uuid id PK
+    uuid user_id FK "recipient"
+    enum type "like|comment|follow|share"
+    uuid actor_id FK "who did it"
+    uuid post_id FK "optional"
+    uuid comment_id FK "optional"
+    boolean is_read
+    timestamp created_at
+  }
+```
+
+補足:
+- 認証は NextAuth.js を想定。必要に応じて `Account`, `Session`, `VerificationToken` を追加可能（Auth.js Prisma Adapter準拠）。
+- 統計値は集計で取得する想定。高頻度で必要なら `post_metrics` や `user_metrics` のマテビュー/集計テーブルを別途追加。


### PR DESCRIPTION
## Summary
- Add Mermaid ER diagram for core domain (users, social graph)
- Add RSS-first ingestion and feed curation tables (rss_source, rss_entry, enclosures, fetch_log, feed_item)
- Keep future `POST` model for upcoming native posts
- Fix Mermaid syntax to render in docs

## Test plan
- View `docs/database-schema.md` in Markdown viewer with Mermaid support
- Verify there are no parse errors
- Confirm entities and relationships match product requirements

## Notes
- Auth.js tables (Account/Session/VerificationToken) can be added when integrating Prisma Adapter
- Composite uniques to be enforced at DB level